### PR TITLE
Fix strace log path detection regex

### DIFF
--- a/Get-ProjectAssemblyAnalysis.py
+++ b/Get-ProjectAssemblyAnalysis.py
@@ -598,7 +598,12 @@ class LogParser:
 
     def parse_strace_log(self, log_path: str) -> Set[str]:
         used_files = set()
-        open_re = re.compile(r'open(?:at)?\([^,]*,\s*"([^"]+)"')
+        # Строки strace могут выглядеть как:
+        #   open("/path/file", O_RDONLY) = 3
+        #   openat(AT_FDCWD, "/path/file", O_RDONLY) = 3
+        # Регулярное выражение ниже извлекает путь из подобных вызовов,
+        # учитывая опциональное "at" и возможные дополнительные параметры.
+        open_re = re.compile(r'open(?:at)?\(.*?"([^"]+)"')
         try:
             with open(log_path, 'r', encoding='utf-8', errors='ignore') as f:
                 for line in f:


### PR DESCRIPTION
## Summary
- fix regex in `parse_strace_log` so paths are detected correctly

## Testing
- `python3 -m py_compile Get-ProjectAssemblyAnalysis.py`
- `python3 Get-ProjectAssemblyAnalysis.py --help | head -n 3`

------
https://chatgpt.com/codex/tasks/task_e_683feb1872dc83309ad90d6163c5f0a1